### PR TITLE
Adds support for `page`, `per_page` parameters for `Transactions.get`

### DIFF
--- a/lib/Transactions.js
+++ b/lib/Transactions.js
@@ -3,6 +3,8 @@
 const APIClient = require('./APIClient.js');
 const Transaction = require('./Transaction.js');
 
+const MAX_BATCH_SIZE = Number.MAX_SAFE_INTEGER; // TODO: replace with actual value
+
 const Transactions = {
   list(client, config, callback) {
       let url = client.baseUrl + '/trans';
@@ -33,6 +35,24 @@ const Transactions = {
           }
         });
       } else {
+        const params = [];
+        if (!isNaN(options.page)) {
+          const pageVal = parseInt(options.page, 10);
+          if (pageVal < 0) {
+            throw new Error('Invalid options param \'page\'');
+          }
+          params.push(`page=${pageVal}`);
+        }
+        if (!isNaN(options.per_page)) {
+          const perPageVal = parseInt(options.per_page, 10);
+          if (perPageVal < 1 || perPageVal > MAX_BATCH_SIZE) {
+            throw new Error('Invalid options param \'per_page\'');
+          }
+          params.push(`per_page=${perPageVal}`);
+        }
+        if (params.length > 0) {
+          url += `?${params.join('&')}`;
+        }
         APIClient.get(url, config, (err, json) => {
           if (err) {
             callback(err);

--- a/samples.md
+++ b/samples.md
@@ -419,7 +419,7 @@ let transactions;
 
 Transactions.get(
   node,
-  null,
+  { page: 0, per_page: 20 },
   function(err, transactionsResp) {
     // error or transaction object
     transactions = transactionsResp;


### PR DESCRIPTION
The two parameter allow pagination for node transactions, per documentation at https://docs.synapsefi.com/docs/all-node-transactions